### PR TITLE
Ambiguous compilation error fix

### DIFF
--- a/source/Game/Map/RaceRail.cpp
+++ b/source/Game/Map/RaceRail.cpp
@@ -68,5 +68,5 @@ void RaceRail::init(const JMapInfoIter &rIter) {
 
 void PlayerRacer::initRacer() {
     AbstractRacer::initRacer();
-    MR::startBckPlayer("Watch", (s32)0);
+    MR::startBckPlayer("Watch", (char*)NULL);
 }

--- a/source/Game/Map/RaceRail.cpp
+++ b/source/Game/Map/RaceRail.cpp
@@ -68,5 +68,5 @@ void RaceRail::init(const JMapInfoIter &rIter) {
 
 void PlayerRacer::initRacer() {
     AbstractRacer::initRacer();
-    MR::startBckPlayer("Watch", 0);
+    MR::startBckPlayer("Watch", (s32)0);
 }

--- a/source/Game/MapObj/HipDropMoveObj.cpp
+++ b/source/Game/MapObj/HipDropMoveObj.cpp
@@ -132,7 +132,7 @@ HipDropMoveObj::~HipDropMoveObj() {
 }
 
 void HipDropDemoMoveObj::moveStart() {
-    MR::startBckPlayer("Wait", 0);
+    MR::startBckPlayer("Wait", (s32)0);
     MtxPtr mtx = MR::getPlayerDemoActor()->getBaseMtx();
     TMtx34f stack_38;
     stack_38.set(mtx);

--- a/source/Game/MapObj/HipDropMoveObj.cpp
+++ b/source/Game/MapObj/HipDropMoveObj.cpp
@@ -132,7 +132,7 @@ HipDropMoveObj::~HipDropMoveObj() {
 }
 
 void HipDropDemoMoveObj::moveStart() {
-    MR::startBckPlayer("Wait", (s32)0);
+    MR::startBckPlayer("Wait", (char*)NULL);
     MtxPtr mtx = MR::getPlayerDemoActor()->getBaseMtx();
     TMtx34f stack_38;
     stack_38.set(mtx);


### PR DESCRIPTION
Master does not compile from a clean build due to ambiguity between const char* and s32. This PR fixes the compilation errors by forcing the type to be resolved as const char*.